### PR TITLE
Conn doesn't always exist for datasources

### DIFF
--- a/tabtosql/workbook.py
+++ b/tabtosql/workbook.py
@@ -95,6 +95,8 @@ def parse_queries(datasources):
 
         name = datasource.attrib['caption']
         conn = datasource.find('connection/relation')
+        if not conn:
+            continue
         query = conn.text if conn.text else '-- LINKED TO: %s' % conn.attrib['table']
 
         query = query.replace('<<', '<').replace('>>', '>')

--- a/tabtosql/workbook.py
+++ b/tabtosql/workbook.py
@@ -95,7 +95,9 @@ def parse_queries(datasources):
 
         name = datasource.attrib['caption']
         conn = datasource.find('connection/relation')
-        query = conn.text if (conn and conn.text) else '-- LINKED TO: %s' % conn.attrib['table']
+        if not conn:
+            continue
+        query = conn.text if conn.text else '-- LINKED TO: %s' % conn.attrib['table']
 
         query = query.replace('<<', '<').replace('>>', '>')
 

--- a/tabtosql/workbook.py
+++ b/tabtosql/workbook.py
@@ -95,9 +95,7 @@ def parse_queries(datasources):
 
         name = datasource.attrib['caption']
         conn = datasource.find('connection/relation')
-        if not conn:
-            continue
-        query = conn.text if conn.text else '-- LINKED TO: %s' % conn.attrib['table']
+        query = conn.text if (conn and conn.text) else '-- LINKED TO: %s' % conn.attrib['table']
 
         query = query.replace('<<', '<').replace('>>', '>')
 

--- a/tabtosql/workbook.py
+++ b/tabtosql/workbook.py
@@ -95,7 +95,7 @@ def parse_queries(datasources):
 
         name = datasource.attrib['caption']
         conn = datasource.find('connection/relation')
-        if not conn:
+        if conn is None:
             continue
         query = conn.text if conn.text else '-- LINKED TO: %s' % conn.attrib['table']
 


### PR DESCRIPTION
Not sure there's a better behavior in this case, but this avoids an AttributeError exception.

`AttributeError: 'NoneType' object has no attribute 'text'`